### PR TITLE
ADDED IN MESSAGE PROPERTIES FOR VALIDATION ERRORS.

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,0 +1,14 @@
+# Set names of properties
+recipe.description=Recipe description
+recipe.cookTime=Cook time
+recipe.url=recipe url
+
+#Validation Messages
+#binding result (in controller) has errors sections which has codes in it
+#codes are in the format of Code.object.field
+#hence can map codes to wording
+
+NotBlank.recipe.description={0} Cannot Be Blank
+Size.recipe.description={0} must be between {2} and {1} characters long.
+Max.recipe.cookTime={0} must be less than {1}
+URL.recipe.url=Please provide a valid {0}

--- a/src/test/java/guru/springframework/recipe/project/recipeproject/controllers/RecipeControllerTest.java
+++ b/src/test/java/guru/springframework/recipe/project/recipeproject/controllers/RecipeControllerTest.java
@@ -40,9 +40,9 @@ public class RecipeControllerTest {
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         recipeController = new RecipeController(recipeService);
-         mockMvc = MockMvcBuilders.standaloneSetup(recipeController)
+        mockMvc = MockMvcBuilders.standaloneSetup(recipeController)
                 .setControllerAdvice(new ControllerExceptionHandler())
-                        .build();
+                .build();
     }
 
     @Test
@@ -124,7 +124,8 @@ public class RecipeControllerTest {
 
         mockMvc.perform(post("/recipe")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("id", ""))
+                .param("id", "")
+                .param("cookTime", "3000"))
                 .andExpect(status().isOk())
                 .andExpect(model().attributeExists("recipe"))
                 .andExpect(view().name("recipe/recipeform"));
@@ -158,7 +159,7 @@ public class RecipeControllerTest {
     @Test
     public void testDeleteRecipe() throws Exception {
 
-         mockMvc.perform(get("/recipe/1/delete"))
+        mockMvc.perform(get("/recipe/1/delete"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name("redirect:/"));
 


### PR DESCRIPTION
First I set friendly names for the property names
Then mapped the specific codes that are returned in the BindingResult(controller).error to a more friendly error message. Use arguments to get values such as max and min